### PR TITLE
make launch4j work again (fix TheBoegl/gradle-launch4j#55)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,8 +27,6 @@ dependencies {
     )
 }
 
-createAllExecutables.dependsOn shadowJar
-
 manifest {
     attributes 'Main-Class': mainClassName
 }
@@ -63,6 +61,5 @@ publishing {
 launch4j {
     outfile = 'zimbus.exe'
     mainClassName = 'com.me.myapp.Driver'
-    icon = 'zimbus.ico'
-    jar = 'build/libs/gradle-launch4j-example.jar'
+    icon = "${projectDir}/zimbus.ico"
 }


### PR DESCRIPTION
This uses the default task wiring for gradle-launch4j and the shadow
plugin. The gradle-launch4j implementation is shadow plugin aware.
Furthermore, the icon should be relative to executable or an absolute
path (see the documentation).